### PR TITLE
fix types import issue in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./dist/mjs/index.js",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
fixes: https://github.com/Shmulik-Kravitz/jewish-date/issues/7

"types" section is ignored when you use "exports" according to https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing

thank https://stackoverflow.com/a/76212193/3026851 for the solution