### PR TITLE
Add pattern-based formatting to format functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,19 @@ console.log(jewishDate); // { year: 5783, monthName: "Iyyar", month: 8, day: 18 
 const jewishDateInEnglish = formatJewishDate(jewishDate);
 console.log(jewishDateInEnglish); // 18 Iyyar 5783
 
+// With custom format pattern (similar to date-fns)
+const formatted = formatJewishDate(jewishDate, "dd/MM/yyyy");
+console.log(formatted); // 18/08/5783
+
 const jewishDateInHebrew = toHebrewJewishDate(jewishDate);
 console.log(jewishDateInHebrew); // { day: "י״ח", monthName: "אייר", year: "התשפ״ג" }
 
 const jewishDateInHebrewStr = formatJewishDateInHebrew(jewishDate);
 console.log(jewishDateInHebrewStr); // י״ח אייר התשפ״ג
+
+// With custom format pattern in Hebrew (gematria)
+const formattedHebrew = formatJewishDateInHebrew(jewishDate, "D/MM/YY");
+console.log(formattedHebrew); // י״ח/02/פ״ג
 
 const date2 = toGregorianDate({
   year: 5783,
@@ -100,6 +108,43 @@ const {
   toGregorianDate,
   JewishMonth,
 } = require("jewish-date");
+```
+
+## Format Patterns
+
+Both `formatJewishDate` and `formatJewishDateInHebrew` accept an optional pattern string as the second argument. The pattern uses tokens similar to [date-fns](https://date-fns.org/docs/format).
+
+### Supported Tokens
+
+| Token  | Description              | `formatJewishDate` | `formatJewishDateInHebrew` |
+| ------ | ------------------------ | ------------------ | -------------------------- |
+| `d`    | Day (numeric)            | 8                  | 8                          |
+| `dd`   | Day (zero-padded)        | 08                 | 08                         |
+| `D`    | Day (gematria in Hebrew) | 8                  | ח׳                         |
+| `M`    | Month number             | 2                  | 2                          |
+| `MM`   | Month number (padded)    | 02                 | 02                         |
+| `MMMM` | Month name               | Iyyar              | אייר                       |
+| `yy`   | Year short (numeric)     | 83                 | 83                         |
+| `YY`   | Year short (gematria)    | 83                 | פ״ג                        |
+| `yyyy` | Year full (numeric)      | 5783               | 5783                       |
+| `YYYY` | Year full (gematria)     | 5783               | התשפ״ג                     |
+
+### Examples
+
+```js
+const jewishDate = toJewishDate(new Date(2023, 4, 9)); // 18 Iyyar 5783
+
+// English formatting (default: "d MMMM yyyy")
+formatJewishDate(jewishDate);                 // "18 Iyyar 5783"
+formatJewishDate(jewishDate, "dd/MM/yyyy");   // "18/08/5783"
+formatJewishDate(jewishDate, "MMMM d, yyyy"); // "Iyyar 18, 5783"
+formatJewishDate(jewishDate, "yyyy-MM-dd");   // "5783-08-18"
+
+// Hebrew formatting (default: "D MMMM YYYY")
+formatJewishDateInHebrew(jewishDate);                 // "י״ח אייר התשפ״ג"
+formatJewishDateInHebrew(jewishDate, "D MMMM YYYY");  // "י״ח אייר התשפ״ג"
+formatJewishDateInHebrew(jewishDate, "dd/MM/yyyy");   // "18/08/5783" (numeric)
+formatJewishDateInHebrew(jewishDate, "d MMMM yyyy");  // "18 אייר 5783" (mixed)
 ```
 
 # License

--- a/__tests__/jewishDate.test.ts
+++ b/__tests__/jewishDate.test.ts
@@ -46,6 +46,54 @@ describe("jewishDate", () => {
     expect(formatJewishDate(jewishDate)).toEqual('1 Tishri 5783');
   });
 
+  it("Format jewish date with default pattern", async () => {
+    const date = new Date(2022, 8, 26);  // the month is 0-indexed
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "d MMMM yyyy")).toEqual('1 Tishri 5783');
+  });
+
+  it("Format jewish date with custom pattern dd/MM/yyyy", async () => {
+    const date = new Date(2023, 3, 26);  // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "dd/MM/yyyy")).toEqual('05/08/5783');
+  });
+
+  it("Format jewish date with custom pattern MMMM d, yyyy", async () => {
+    const date = new Date(2023, 3, 26);  // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "MMMM d, yyyy")).toEqual('Iyyar 5, 5783');
+  });
+
+  it("Format jewish date with short year yy", async () => {
+    const date = new Date(2023, 3, 26);  // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "d/M/yy")).toEqual('5/8/83');
+  });
+
+  it("Format jewish date with yyyy-MM-dd pattern", async () => {
+    const date = new Date(2023, 3, 26);  // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "yyyy-MM-dd")).toEqual('5783-08-05');
+  });
+
+  it("Format jewish date with trailing literal text", async () => {
+    const date = new Date(2023, 3, 26);  // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "d MMMM yyyy!")).toEqual('5 Iyyar 5783!');
+  });
+
+  it("Format jewish date with uppercase D token", async () => {
+    const date = new Date(2023, 3, 26);  // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "D MMMM YYYY")).toEqual('5 Iyyar 5783');
+  });
+
+  it("Format jewish date with uppercase YY token", async () => {
+    const date = new Date(2023, 3, 26);  // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    expect(formatJewishDate(jewishDate, "d/M/YY")).toEqual('5/8/83');
+  });
+
   it("Get index by jewish month with invalid value", () => {
     const jewishDate = getIndexByJewishMonth("invalid" as unknown as JewishMonthType);
     expect(jewishDate).toStrictEqual(0);

--- a/__tests__/jewishDateHebrew.test.ts
+++ b/__tests__/jewishDateHebrew.test.ts
@@ -6,6 +6,7 @@ import {
   convertNumberToHebrew,
   getJewishMonthInHebrew,
   toHebrewJewishDate,
+  convertYearToShortHebrew,
 } from "../src";
 
 describe("jewishDateHebrew", () => {
@@ -35,5 +36,45 @@ describe("jewishDateHebrew", () => {
     const jewishDate = toJewishDate(date);
     const jewishDateInHebrew = formatJewishDateInHebrew(jewishDate);
     expect(jewishDateInHebrew).toStrictEqual("א׳ תשרי התשפ״ג");
+  });
+
+  it("Convert year to short hebrew", () => {
+    const shortYear = convertYearToShortHebrew(5783);
+    expect(shortYear).toStrictEqual("פ״ג");
+  });
+
+  it("Format jewish date in hebrew with explicit gematria pattern", () => {
+    const date = new Date(2022, 8, 26); // the month is 0-indexed
+    const jewishDate = toJewishDate(date);
+    const jewishDateInHebrew = formatJewishDateInHebrew(jewishDate, "D MMMM YYYY");
+    expect(jewishDateInHebrew).toStrictEqual("א׳ תשרי התשפ״ג");
+  });
+
+  it("Format jewish date in hebrew with numeric pattern dd/MM/yyyy", () => {
+    const date = new Date(2023, 3, 26); // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    const jewishDateInHebrew = formatJewishDateInHebrew(jewishDate, "dd/MM/yyyy");
+    expect(jewishDateInHebrew).toStrictEqual("05/02/5783");
+  });
+
+  it("Format jewish date in hebrew with short numeric year yy", () => {
+    const date = new Date(2023, 3, 26); // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    const jewishDateInHebrew = formatJewishDateInHebrew(jewishDate, "d/M/yy");
+    expect(jewishDateInHebrew).toStrictEqual("5/2/83");
+  });
+
+  it("Format jewish date in hebrew with gematria day and year", () => {
+    const date = new Date(2023, 3, 26); // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    const jewishDateInHebrew = formatJewishDateInHebrew(jewishDate, "D/MM/YY");
+    expect(jewishDateInHebrew).toStrictEqual("ה׳/02/פ״ג");
+  });
+
+  it("Format jewish date in hebrew with mixed numeric and Hebrew", () => {
+    const date = new Date(2023, 3, 26); // 5 Iyyar 5783
+    const jewishDate = toJewishDate(date);
+    const jewishDateInHebrew = formatJewishDateInHebrew(jewishDate, "d MMMM yyyy");
+    expect(jewishDateInHebrew).toStrictEqual("5 אייר 5783");
   });
 });

--- a/src/jewishDate.ts
+++ b/src/jewishDate.ts
@@ -19,7 +19,11 @@ import {
   jdToGregorian,
   jdToHebrew,
 } from "./utils/dateUtils/dateUtils";
-import { toLength } from "./utils/numberUtils/numberUtils";
+import {
+  DEFAULT_PATTERN,
+  formatWithPattern,
+  getEnglishFormatters,
+} from "./utils/formatUtils";
 
 /**
  * Checks if the given year is a leap year according to the Jewish calendar.
@@ -138,12 +142,29 @@ export const getJewishMonthsInOrder = (year: number): string[] => {
 };
 
 /**
- * Returns a string representation of the given Jewish date in the format 'כ"א ניסן תשפ"ג'.
+ * Returns a string representation of the given Jewish date.
  * @param {JewishDate} jewishDate - The Jewish date to format.
- * @returns {string} A string representation of the given Jewish date in the format 'כ"א ניסן תשפ"ג'.
+ * @param {string} [pattern] - Optional format pattern (e.g., "d MMMM yyyy", "dd/MM/yy").
+ *   Supported tokens: d (day), dd (day padded), D (day), M (month), MM (month padded),
+ *   MMMM (month name), yy (short year), YY (short year), yyyy (full year), YYYY (full year).
+ *   Default pattern: "d MMMM yyyy"
+ * @returns {string} A string representation of the given Jewish date.
  */
-export const formatJewishDate = (jewishDate: JewishDate): string => {
-  return `${jewishDate.day} ${jewishDate.monthName} ${jewishDate.year}`;
+export const formatJewishDate = (
+  jewishDate: JewishDate,
+  pattern?: string,
+): string => {
+  const formatPattern = pattern ?? DEFAULT_PATTERN;
+  return formatWithPattern(
+    formatPattern,
+    {
+      day: jewishDate.day,
+      month: jewishDate.month,
+      monthName: jewishDate.monthName,
+      year: jewishDate.year,
+    },
+    getEnglishFormatters,
+  );
 };
 
 /**

--- a/src/jewishDateHebrew.ts
+++ b/src/jewishDateHebrew.ts
@@ -13,6 +13,12 @@ import type {
   JewishMonthType,
 } from "./interfaces";
 import { JewishMonth } from "./interfaces";
+import { getIndexByJewishMonth } from "./jewishDate";
+import {
+  DEFAULT_PATTERN_HEBREW,
+  createHebrewFormatters,
+  formatWithPattern,
+} from "./utils/formatUtils";
 
 /**
  * Returns the name of a Jewish month in Hebrew, given its type.
@@ -59,6 +65,17 @@ export const convertNumberToHebrew = (
 };
 
 /**
+ * Converts a year to its short Hebrew equivalent (last two significant digits).
+ * For example, 5783 → פ״ג (83 in gematria)
+ * @param year - The year to convert
+ * @returns The short Hebrew equivalent of the year
+ */
+export const convertYearToShortHebrew = (year: number): string => {
+  const shortYear = year % 100;
+  return gematriya(shortYear, { geresh: true, punctuate: true });
+};
+
+/**
  * Converts a basic Jewish date object to a Hebrew date object with Hebrew letters.
  * @param {BasicJewishDate} jewishDate - The basic Jewish date object to convert.
  * @returns {BasicJewishDateHebrew} The Hebrew date object with Hebrew letters.
@@ -76,11 +93,32 @@ export const toHebrewJewishDate = (
 /**
  * Formats a Jewish date object into a string representation in Hebrew.
  * @param {BasicJewishDate} jewishDate - The Jewish date object to format.
+ * @param {string} [pattern] - Optional format pattern (e.g., "D MMMM YYYY", "dd/MM/yyyy").
+ *   Supported tokens:
+ *   - Lowercase (numeric): d, dd (day), M, MM (month), yy, yyyy (year)
+ *   - Uppercase (gematria): D (day), YY, YYYY (year)
+ *   - MMMM (Hebrew month name)
+ *   Default pattern: "D MMMM YYYY" (all Hebrew gematria)
  * @returns {string} The Hebrew string representation of the Jewish date.
  */
 export const formatJewishDateInHebrew = (
   jewishDate: BasicJewishDate,
+  pattern?: string,
 ): string => {
-  const jewishDateInHebrew = toHebrewJewishDate(jewishDate);
-  return `${jewishDateInHebrew.day} ${jewishDateInHebrew.monthName} ${jewishDateInHebrew.year}`;
+  const formatPattern = pattern ?? DEFAULT_PATTERN_HEBREW;
+  const hebrewFormatters = createHebrewFormatters(
+    convertNumberToHebrew,
+    (monthName) => getJewishMonthInHebrew(monthName as JewishMonthType),
+    convertYearToShortHebrew,
+  );
+  return formatWithPattern(
+    formatPattern,
+    {
+      day: jewishDate.day,
+      month: getIndexByJewishMonth(jewishDate.monthName),
+      monthName: jewishDate.monthName,
+      year: jewishDate.year,
+    },
+    hebrewFormatters,
+  );
 };

--- a/src/utils/formatUtils/formatUtils.ts
+++ b/src/utils/formatUtils/formatUtils.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) Shmulik Kravitz.
+ *
+ * This source code is licensed under the MIT license.
+ * See the LICENSE file in the root directory for more information.
+ *
+ */
+
+import { toLength } from "../numberUtils/numberUtils";
+
+/**
+ * Token definitions for pattern parsing.
+ * Order matters - longer tokens must come first to avoid partial matches.
+ */
+const TOKEN_PATTERNS = [
+  "yyyy",
+  "YYYY",
+  "yy",
+  "YY",
+  "MMMM",
+  "MM",
+  "M",
+  "dd",
+  "D",
+  "d",
+] as const;
+
+type TokenType = (typeof TOKEN_PATTERNS)[number];
+
+interface TokenMatch {
+  token: TokenType;
+  index: number;
+}
+
+/**
+ * Represents the components needed for formatting a Jewish date.
+ */
+export interface FormatComponents {
+  day: number;
+  month: number;
+  monthName: string;
+  year: number;
+}
+
+/**
+ * Formatter function type that converts a component to its string representation.
+ */
+type TokenFormatter = (components: FormatComponents) => string;
+
+/**
+ * Creates formatters for English (numeric) output.
+ * In English mode, uppercase tokens behave the same as lowercase (numeric output).
+ */
+const createEnglishFormatters = (): Record<TokenType, TokenFormatter> => ({
+  d: (c) => c.day.toString(),
+  dd: (c) => toLength(c.day, 2),
+  D: (c) => c.day.toString(),
+  M: (c) => c.month.toString(),
+  MM: (c) => toLength(c.month, 2),
+  MMMM: (c) => c.monthName,
+  yy: (c) => (c.year % 100).toString().padStart(2, "0"),
+  YY: (c) => (c.year % 100).toString().padStart(2, "0"),
+  yyyy: (c) => c.year.toString(),
+  YYYY: (c) => c.year.toString(),
+});
+
+/**
+ * Creates formatters for Hebrew output.
+ * Lowercase tokens (d, M, y) output numeric values.
+ * Uppercase tokens (D, YY, YYYY) output Hebrew gematria.
+ * MMMM outputs Hebrew month name.
+ * @param convertToHebrew - Function to convert numbers to Hebrew gematria
+ * @param getHebrewMonthName - Function to get Hebrew month name
+ * @param getShortYearHebrew - Function to get short (2-letter) Hebrew year
+ */
+export const createHebrewFormatters = (
+  convertToHebrew: (num: number) => string,
+  getHebrewMonthName: (monthName: string) => string,
+  getShortYearHebrew: (year: number) => string,
+): Record<TokenType, TokenFormatter> => ({
+  d: (c) => c.day.toString(),
+  dd: (c) => toLength(c.day, 2),
+  D: (c) => convertToHebrew(c.day),
+  M: (c) => c.month.toString(),
+  MM: (c) => toLength(c.month, 2),
+  MMMM: (c) => getHebrewMonthName(c.monthName),
+  yy: (c) => (c.year % 100).toString().padStart(2, "0"),
+  YY: (c) => getShortYearHebrew(c.year),
+  yyyy: (c) => c.year.toString(),
+  YYYY: (c) => convertToHebrew(c.year),
+});
+
+/**
+ * Finds all tokens in the pattern string.
+ */
+const findTokens = (pattern: string): TokenMatch[] => {
+  const matches: TokenMatch[] = [];
+  let searchStart = 0;
+
+  while (searchStart < pattern.length) {
+    let foundMatch: TokenMatch | null = null;
+
+    // Try each token pattern (longest first)
+    for (const token of TOKEN_PATTERNS) {
+      const index = pattern.indexOf(token, searchStart);
+      if (index === searchStart) {
+        foundMatch = { token, index };
+        break;
+      }
+    }
+
+    if (foundMatch) {
+      matches.push(foundMatch);
+      searchStart = foundMatch.index + foundMatch.token.length;
+    } else {
+      searchStart++;
+    }
+  }
+
+  return matches;
+};
+
+/**
+ * Formats a Jewish date using the given pattern and formatters.
+ * @param pattern - The format pattern string (e.g., "d MMMM yyyy")
+ * @param components - The date components to format
+ * @param formatters - Token formatters to use
+ * @returns The formatted date string
+ */
+export const formatWithPattern = (
+  pattern: string,
+  components: FormatComponents,
+  formatters: Record<TokenType, TokenFormatter>,
+): string => {
+  const tokens = findTokens(pattern);
+  let result = "";
+  let lastIndex = 0;
+
+  for (const { token, index } of tokens) {
+    // Add any literal text before this token
+    if (index > lastIndex) {
+      result += pattern.slice(lastIndex, index);
+    }
+    // Add the formatted token value
+    result += formatters[token](components);
+    lastIndex = index + token.length;
+  }
+
+  // Add any remaining literal text
+  if (lastIndex < pattern.length) {
+    result += pattern.slice(lastIndex);
+  }
+
+  return result;
+};
+
+/**
+ * Default pattern for formatting Jewish dates (numeric).
+ */
+export const DEFAULT_PATTERN = "d MMMM yyyy";
+
+/**
+ * Default pattern for formatting Jewish dates in Hebrew (gematria).
+ */
+export const DEFAULT_PATTERN_HEBREW = "D MMMM YYYY";
+
+/**
+ * Gets the English formatters (singleton).
+ */
+export const getEnglishFormatters = createEnglishFormatters();

--- a/src/utils/formatUtils/index.ts
+++ b/src/utils/formatUtils/index.ts
@@ -1,0 +1,1 @@
+export * from "./formatUtils";


### PR DESCRIPTION
Add optional pattern parameter to formatJewishDate and formatJewishDateInHebrew
functions, similar to date-fns format function.

Supported tokens:
- Lowercase (numeric): d, dd (day), M, MM (month), yy, yyyy (year)
- Uppercase (gematria in Hebrew mode): D (day), YY, YYYY (year)
- MMMM: month name (English or Hebrew based on function)

In formatJewishDate, all tokens output numeric/English values.
In formatJewishDateInHebrew, lowercase outputs numbers, uppercase outputs gematria.

Default patterns:
- formatJewishDate: "d MMMM yyyy"
- formatJewishDateInHebrew: "D MMMM YYYY"